### PR TITLE
enable only admin user to accept/reject requests

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,17 @@
 class TasksController < ApplicationController
   def create
+    if !@current_user
+      flash[:notice] = "ログインしてください"
+      redirect_to service_path and return
+    end
+    host_user = HostUser.find_by(user_id: @current_user.id)
+    if !host_user
+      flash[:notice] = "Host Userでないためリクエストの承認/拒否はできません"
+      redirect_to service_path and return
+    end
+
     @task = Task.new(task_params)
+    @task[:host_user_id] = host_user.id
     error_msgs = []
     ActiveRecord::Base.transaction do
       if !@task.save

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
         error_msgs << user.errors.full_messages
         raise ActiveRecord::Rollback
       end
-      if params.require(:user).permit(:is_host)
+      if params[:user][:is_host]
         host_user = HostUser.new({user_id: user.id, image: 'no_icon.png'})
         if !host_user.save
           error_msgs << host_user.errors.full_messages

--- a/app/views/service/index.html.erb
+++ b/app/views/service/index.html.erb
@@ -206,7 +206,7 @@
                         <div class="">
                             <%= f.hidden_field :request_id, {id: "checkFormRequest_id"} %>
                             <%= f.hidden_field :isAccepted %>
-                            <%= f.hidden_field :host_user_id, value: 1 %>
+                            <%# f.hidden_field :host_user_id, value: 1 %>
                         </div>
                         <p>理由:</p>
                         <div class="">

--- a/app/views/tasks/index_rejected.html.erb
+++ b/app/views/tasks/index_rejected.html.erb
@@ -34,7 +34,12 @@
                             <div class="flex justify-between">
                                 <div class="my-auto font-bold text-lg inset-y-0">拒否理由</div>
                                 <div>
-                                    <div class="inline-block align-middle rounded-full h-12 w-12 bg-red-100"><%= task.host_user.image %></div>
+                                    <% task_image_path = "public/host_user_icons/#{task.host_user.id}_#{task.host_user.image}" %>
+                                    <% if File.exist?(task_image_path) %>
+                                        <%= image_tag "/host_user_icons/#{request.id}_#{request.image.force_encoding("UTF-8")}", class: "w-32 h-32 object-cover rounded-l-lg" %>
+                                    <% else %>
+                                        <%= image_tag "/host_user_icons/no_icon.png", class: "inline-block align-middle rounded-full h-12 w-12 bg-red-100" %>
+                                    <% end %>
                                     <div class="inline-block align-middle font-bold text-lg w-max mx-2"><%= task.host_user.position %></div>
                                 </div>
                             </div>


### PR DESCRIPTION
:close #23 
管理者ユーザのみタスクの承認/拒否ができるようにした
accepted listとrejected listのタスクに管理者ユーザのアイコンが表示されるようにした
全てのユーザが管理者として登録されてしまうバグを修正